### PR TITLE
Fix digitsize computation

### DIFF
--- a/Source/PixelRendr.ts
+++ b/Source/PixelRendr.ts
@@ -1285,7 +1285,11 @@ module PixelRendr {
          *                  any index of the palettte).
          */
         private getDigitSize(palette: any[]): number {
-            return Math.floor(Math.log(palette.length) / Math.LN10) + 1;
+            var digitsize: number = 0;
+            for (var n: number = palette.length; n >= 1; n /= 10) {
+                ++digitsize;
+            }
+            return digitsize;
         }
 
         /**

--- a/Source/PixelRendr.ts
+++ b/Source/PixelRendr.ts
@@ -869,7 +869,10 @@ module PixelRendr {
                             // Isolate and split the new palette's numbers
                             paletteref = this.getPaletteReference(colors.slice(loc + 1, nixloc).split(","));
                             loc = nixloc + 1;
-                            digitsize = 1;
+                            digitsize = 0;
+                            for (var n: number = Object.keys(paletteref).length; n >= 1; n /= 10) {
+                                ++digitsize;
+                            }
                         } else {
                             // Otherwise go back to default
                             paletteref = this.getPaletteReference(this.paletteDefault);


### PR DESCRIPTION
The following sprite of a Goomba twice bigger than the current one in FSM has been generated by ImageReadr but caused an error in FSM.

"p[00,02,03,04,05,06,09,11,15,22]x0011,x0610,x0020,x0614,x0018,x0614,x0016,x0618,x0014,x0618,x0012,x0622,x0010,x0622,x008,x0626,x006,06060607010107x0612,07010107060606x004,x065,0701080707x0610,0707080107x065,0000x067,03030707x068,07070303x067,0000x066,050902080107x066,070108020905x066,0000x066,05090208x0110,08020905x066,00x067,05090208010808x014,08080108020905x0614,05090208080303x064,03030808020905x0614,050902030302090506060509020303020905x0614,050904020204090506060509040202040905x0615,05x094,05x064,05x094,05x0617,x054,x066,x054,x0620,x0510,x0621,05x0910,05x0610,00x068,0509x0410,0905x068,0000x066,050909x0412,090905x066,x008,0309x0416,x0011,0101010802x0416,x0011,0101010803020202x0410,020303x009,x016,0808080302x048,0203080101x008,x019,080302x046,020308010101x008,x0110,080302x044,020308x014,x008,x0111,0803040409020308x015,x0010,x0110,030404030808x014,x0012,x0110,x004,x016,x008,"